### PR TITLE
Add support for container logging config

### DIFF
--- a/docrane/util.py
+++ b/docrane/util.py
@@ -126,7 +126,8 @@ def convert_params(params):
         'volumes': None,
         'environment': None,
         'command': None,
-        'links': None}
+        'links': None,
+        'log_config': None}
 
     for param in params.iterkeys():
         if params.get(param) and param in c_params.keys():
@@ -164,14 +165,14 @@ def create_docker_container(name, params):
     client = _get_docker_client()
 
     LOG.info("Creating with params: %s" % params)
-
     hostconfig = client.create_host_config(
         port_bindings=params.get('config_ports'),
         volumes_from=params.get('volumes_from'),
         binds=params.get('volume_bindings', {}),
         links=params.get('links'),
         mem_limit=params.get('mem_limit'),
-        privileged=params.get('privileged'))
+        privileged=params.get('privileged'),
+        log_config=params.get('log_config'))
 
     client.create_container(
         image=params.get('image'),

--- a/docrane/util.py
+++ b/docrane/util.py
@@ -165,6 +165,7 @@ def create_docker_container(name, params):
     client = _get_docker_client()
 
     LOG.info("Creating with params: %s" % params)
+
     hostconfig = client.create_host_config(
         port_bindings=params.get('config_ports'),
         volumes_from=params.get('volumes_from'),


### PR DESCRIPTION
To modify a container's log config, set its "log_config" key to a dictionary with keys "type" (for the type of logging driver) and "config" (for any extra configuration the logging driver might need).

E.g. docrane would pick up the following config and start logging using the GELF driver:

```
etcdctl set /docrane/example_containter/log_config \
  '{"type": "gelf", "config": {"gelf-address":"udp://host:8201"}}'
```
