### PR TITLE
Add support for container networking config

### DIFF
--- a/docrane/util.py
+++ b/docrane/util.py
@@ -127,7 +127,8 @@ def convert_params(params):
         'environment': None,
         'command': None,
         'links': None,
-        'log_config': None}
+        'log_config': None,
+        'networking_config': None}
 
     for param in params.iterkeys():
         if params.get(param) and param in c_params.keys():
@@ -184,6 +185,7 @@ def create_docker_container(name, params):
         command=params.get('command'),
         hostname=params.get('hostname'),
         cpu_shares=params.get('cpu_shares'),
+        networking_config=params.get('networking_config'),
         host_config=hostconfig,
         name=name)
 


### PR DESCRIPTION
To modify a container's networking config, set its "networking_config" key to a docker-py NetworkingConfig dictionary.

E.g. docrane would pick up the following config:

```
etcdctl set /docrane/example_containter/networking_config \
  '{"EndpointsConfig": {"named_network": None}'
```

and ensure that the container started connected to the network "named_network" with the default configuration.
